### PR TITLE
fix: subgraph native token tracker

### DIFF
--- a/packages/oracle-subgraph/bin/build-subgraph.ts
+++ b/packages/oracle-subgraph/bin/build-subgraph.ts
@@ -33,6 +33,8 @@ async function main() {
     let dxdTokenAdresss = "0xa1d65e8fb6e87b60feccbc582f7f97804b725521";
     let startBlock = 16341493; // this block emits a NewCallProposal event from DAOstack scheme
 
+    startBlock = await getBlockNumber(network);
+
     // fetch recent block number
     // const startBlock = await getBlockNumber(network);
     let source = {
@@ -47,9 +49,14 @@ async function main() {
             handler: "handleInitSubgraph",
         },
     ];
+    const blockHandlers = [
+        {
+            handler: "handleBlock",
+        },
+    ];
 
     if (network === "xdai") {
-        startBlock = 25836452;
+        // startBlock = 25836452;
         dxdTokenAdresss = "0xb90d6bec20993be5d72a5ab353343f7a0281f158";
         source = {
             address: "0xa80ea8941f1772792beb99648ba4ff8dc1d4c849",
@@ -100,7 +107,7 @@ async function main() {
                             file: "./abis/DXdaoNAV.json",
                         },
                     ],
-                    eventHandlers,
+                    blockHandlers,
                 },
             },
             {

--- a/packages/oracle-subgraph/src/helpers/token.ts
+++ b/packages/oracle-subgraph/src/helpers/token.ts
@@ -1,5 +1,5 @@
 import { Address } from "@graphprotocol/graph-ts";
 
 export function addressEqual(a: Address, b: Address): boolean {
-    return a.toHexString().toLowerCase() === b.toHexString().toLowerCase()
+    return a.toHexString().toLowerCase() == b.toHexString().toLowerCase()
 }

--- a/packages/oracle-subgraph/src/mappings/constants.ts
+++ b/packages/oracle-subgraph/src/mappings/constants.ts
@@ -1,4 +1,4 @@
-import { Address, dataSource } from "@graphprotocol/graph-ts";
+import { Address, BigInt, dataSource } from "@graphprotocol/graph-ts";
 
 export const ZERO_ADDRESS = Address.fromString(
     "0x0000000000000000000000000000000000000000"
@@ -15,6 +15,8 @@ export const MULTICALL3_ADDRESS = Address.fromString(
 export const MAINNET = "mainnet";
 export const XDAI = "xdai";
 export const ARBITRUM_ONE = "arbitrum-one";
+export const SNAPSHOT_FREQUENCY = BigInt.fromI32(dataSource.network() == MAINNET ? 10 : 60); // 10 blocks on Ethereum, 60 blocks on Gnosis Chain
+export const ZERO = BigInt.fromI32(0)
 
 // DXdao Avatar DXD vesting address
 export let DXDAO_AVATAR_DXD_VESTING_ADDRESS = Address.fromString(
@@ -37,12 +39,19 @@ export class DXdaoSafes {
     static xdai(): Address[] {
         return [];
     }
+
+    static arbitrumOne(): Address[] {
+        return [];
+    }
+
     static addressList(): Address[] {
         let network = dataSource.network() as string;
         if (network == MAINNET)
             return DXdaoSafes.mainnet().concat(DXdaoSafes.multichain());
         if (network == XDAI)
             return DXdaoSafes.xdai().concat(DXdaoSafes.multichain());
+        if (network == ARBITRUM_ONE)
+            return DXdaoSafes.arbitrumOne().concat(DXdaoSafes.multichain());
         return [];
     }
 }
@@ -113,13 +122,19 @@ export class SWPR {
 
 export class DXdaoAvatar {
     static address(): Address {
-        if (dataSource.network() == MAINNET)
+        const network = dataSource.network() as string;
+
+        if (network == MAINNET)
             return Address.fromString(
                 "0x519b70055af55A007110B4Ff99b0eA33071c720a"
             );
-        if (dataSource.network() == XDAI)
+        if (network == XDAI)
             return Address.fromString(
                 "0xe716ec63c5673b3a4732d22909b38d779fa47c3f"
+            );
+        if (network == ARBITRUM_ONE)
+            return Address.fromString(
+                "0x2B240b523f69b9aF3adb1C5924F6dB849683A394"
             );
         return ZERO_ADDRESS;
     }
@@ -154,10 +169,18 @@ export class DXdaoNavTokens {
         ];
     }
 
+    static arbitrumOne(): Address[] {
+        return [
+            Address.fromString("0xff970a61a04b1ca14834a43f5de4533ebddb5cc8"),
+            SWPR.address(),
+        ];
+    }
+
     static addressList(): Address[] {
         let network = dataSource.network() as string;
         if (network == MAINNET) return DXdaoNavTokens.mainnet();
         if (network == XDAI) return DXdaoNavTokens.xdai();
+        if (network == ARBITRUM_ONE) return DXdaoNavTokens.arbitrumOne();
         return [];
     }
 }

--- a/packages/oracle-subgraph/src/mappings/subgraphStatus.ts
+++ b/packages/oracle-subgraph/src/mappings/subgraphStatus.ts
@@ -4,7 +4,7 @@ import { SubgraphStatus } from "../../generated/schema";
 export function updateSubgraphStatus(blockNumber: BigInt): void {
     let subgraphStatus = SubgraphStatus.load("1");
 
-    if (subgraphStatus === null) {
+    if (subgraphStatus == null) {
         subgraphStatus = new SubgraphStatus("1");
     }
     subgraphStatus.lastSnapshotBlock = blockNumber;

--- a/packages/oracle-subgraph/src/mappings/token.ts
+++ b/packages/oracle-subgraph/src/mappings/token.ts
@@ -45,6 +45,7 @@ export function handleDXDTrasnfer(event: Transfer): void {
     }
     updateDXDCirculatingSupplySnapshot(blockNumber, supplyChange);
     updateSubgraphStatus(blockNumber);
+
     return;
 }
 

--- a/packages/oracle/src/utils/subgraph/index.ts
+++ b/packages/oracle/src/utils/subgraph/index.ts
@@ -109,13 +109,14 @@ export async function getTokenBalancesSnapshotAtBlock(
     for (const [rawChainId, subgraphEndpoint] of Object.entries(
         subgraphEndpointList
     )) {
-        const chainId = (rawChainId as unknown) as ChainId;
+        const chainId = rawChainId as unknown as ChainId;
         const blockTag = block[chainId];
         enforce(!!blockTag, `no block tag specified for chain id ${chainId}`);
         const graphqlClient = new GraphQLClient(subgraphEndpoint);
-        responseList[chainId] = await graphqlClient.request<
-            NAVSnapshotResponse
-        >(buildSubgraphQuery(blockTag));
+        responseList[chainId] =
+            await graphqlClient.request<NAVSnapshotResponse>(
+                buildSubgraphQuery(blockTag)
+            );
     }
 
     // Total supply is from Ethereum chain
@@ -158,12 +159,6 @@ export async function getTokenBalancesSnapshotAtBlock(
         const tokenId = `${
             balance.token.chainId
         }-${token.address.toLowerCase()}`;
-
-        let amount = BigNumber.from(balance.amount);
-
-        if (acc[tokenId]) {
-            amount = amount.add(acc[tokenId].toRawAmount());
-        }
 
         let amount = BigNumber.from(balance.amount);
 

--- a/packages/oracle/src/utils/subgraph/index.ts
+++ b/packages/oracle/src/utils/subgraph/index.ts
@@ -109,14 +109,13 @@ export async function getTokenBalancesSnapshotAtBlock(
     for (const [rawChainId, subgraphEndpoint] of Object.entries(
         subgraphEndpointList
     )) {
-        const chainId = rawChainId as unknown as ChainId;
+        const chainId = (rawChainId as unknown) as ChainId;
         const blockTag = block[chainId];
         enforce(!!blockTag, `no block tag specified for chain id ${chainId}`);
         const graphqlClient = new GraphQLClient(subgraphEndpoint);
-        responseList[chainId] =
-            await graphqlClient.request<NAVSnapshotResponse>(
-                buildSubgraphQuery(blockTag)
-            );
+        responseList[chainId] = await graphqlClient.request<
+            NAVSnapshotResponse
+        >(buildSubgraphQuery(blockTag));
     }
 
     // Total supply is from Ethereum chain
@@ -159,6 +158,12 @@ export async function getTokenBalancesSnapshotAtBlock(
         const tokenId = `${
             balance.token.chainId
         }-${token.address.toLowerCase()}`;
+
+        let amount = BigNumber.from(balance.amount);
+
+        if (acc[tokenId]) {
+            amount = amount.add(acc[tokenId].toRawAmount());
+        }
 
         let amount = BigNumber.from(balance.amount);
 


### PR DESCRIPTION
# Summary

Adds `blockHandlers` for each chain: NAV snapshots are updated 10 and 60 blocks on Ethereum and Gnosis Chain respectively. 